### PR TITLE
feat(sorting): Implement sorting on our tables

### DIFF
--- a/concert_elephant/static/css/project.css
+++ b/concert_elephant/static/css/project.css
@@ -141,3 +141,20 @@ thead.table-custom {
   background-color: #A8A196;
   transition: 0.7s;
 }
+
+.sort-icon .default-icon {
+  display: inline-block; /* By default, show the default icon */
+  color: black;
+}
+
+.sort-icon i.asc-icon, .sort-icon i.desc-icon {
+  color: black;
+}
+
+.sort-icon i.active {
+  display: inline-block; /* Show the icon with the 'active' class */
+}
+
+.hidden {
+  display: none !important;
+}

--- a/concert_elephant/static/js/project.js
+++ b/concert_elephant/static/js/project.js
@@ -1,1 +1,0 @@
-/* Project specific Javascript goes here. */

--- a/concert_elephant/static/js/user_detail.js
+++ b/concert_elephant/static/js/user_detail.js
@@ -145,8 +145,9 @@ document.addEventListener("DOMContentLoaded", function() {
 
     document.querySelector('#confirmDeleteBtn').addEventListener('click', function() {
         const reviewId = document.getElementById('reviewId').value;
+        const deleteURL = deleteReviewURLTemplate.replace(0, reviewId);
 
-        fetch(deleteReviewURLTemplate.replace('REVIEW_ID', reviewId), {
+        fetch(deleteURL,{
             method: 'DELETE',
             headers: {
                 'X-Requested-With': 'XMLHttpRequest',

--- a/concert_elephant/templates/base.html
+++ b/concert_elephant/templates/base.html
@@ -46,7 +46,6 @@
               crossorigin="anonymous"
               referrerpolicy="no-referrer"></script>
       <!-- place project specific Javascript in this file -->
-      <script defer src="{% static 'js/project.js' %}"></script>
     {% endblock javascript %}
   </head>
   <body>

--- a/concert_elephant/templates/concerts/artist_list.html
+++ b/concert_elephant/templates/concerts/artist_list.html
@@ -18,8 +18,34 @@
           <table class="table table-striped table-hover">
             <thead class="table-custom">
               <tr>
-                <th class="text-center" scope="col">Artist</th>
-                <th class="text-center" scope="col">Concerts</th>
+                <th class="text-center" scope="col">
+                  Artist
+                  <span class="sort-icon" data-sort="name">
+                    <a href="{% if request.GET.sort_by == "name" %}?sort_by=-name{% else %}?sort_by=name{% endif %}">
+                      <i title="Sort" class="bi bi-arrow-down-up default-icon {% if "name" in request.GET.sort_by or "-name" in request.GET.sort_by %}hidden{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=-name">
+                      <i title="Change to descending" class="bi bi-arrow-up asc-icon {% if request.GET.sort_by == "name" %}active{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=name">
+                      <i title="Change to ascending" class="bi bi-arrow-down desc-icon {% if request.GET.sort_by == "-name" %}active{% endif %}"></i>
+                    </a>
+                  </span>
+                </th>
+                <th class="text-center" scope="col">
+                  Concerts
+                  <span class="sort-icon" data-sort="concert_count">
+                    <a href="{% if request.GET.sort_by == "concert_count" %}?sort_by=-concert_count{% else %}?sort_by=concert_count{% endif %}">
+                      <i title="Sort" class="bi bi-arrow-down-up default-icon {% if "concert_count" in request.GET.sort_by or "-concert_count" in request.GET.sort_by %}hidden{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=-concert_count">
+                      <i title="Change to descending" class="bi bi-arrow-up asc-icon {% if request.GET.sort_by == "concert_count" %}active{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=concert_count">
+                      <i title="Change to ascending" class="bi bi-arrow-down desc-icon {% if request.GET.sort_by == "-concert_count" %}active{% endif %}"></i>
+                    </a>
+                  </span>
+                </th>
               </tr>
             </thead>
             {% for artist in page_obj %}

--- a/concert_elephant/templates/concerts/concert_list.html
+++ b/concert_elephant/templates/concerts/concert_list.html
@@ -21,25 +21,43 @@
                 <th scope="col" class="text-center">
                   Artist
                   <span class="sort-icon" data-sort="artist">
-                    <i title="Sort" class="bi bi-arrow-down-up default-icon"></i>
-                    <i title="Change to descending" class="bi bi-arrow-up asc-icon"></i>
-                    <i title="Change to ascending" class="bi bi-arrow-down desc-icon"></i>
+                      <a href="?sort_by=artist">
+                        <i title="Sort" class="bi bi-arrow-down-up default-icon {% if request.GET.sort_by == "artist" or request.GET.sort_by == "-artist" %}hidden{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=-artist">
+                        <i title="Change to descending" class="bi bi-arrow-down asc-icon {% if request.GET.sort_by == "artist" %}active{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=artist">
+                        <i title="Change to ascending" class="bi bi-arrow-up desc-icon {% if request.GET.sort_by == "-artist" %}active{% endif %}"></i>
+                    </a>
                   </span>
                 </th>
                 <th scope="col" class="text-center">
                   Venue
                   <span class="sort-icon" data-sort="venue">
-                    <i title="Sort" class="bi bi-arrow-down-up default-icon"></i>
-                    <i title="Change to descending" class="bi bi-arrow-up asc-icon"></i>
-                    <i title="Change to ascending" class="bi bi-arrow-down desc-icon"></i>
+                    <a href="?sort_by=venue">
+                        <i title="Sort" class="bi bi-arrow-down-up default-icon {% if request.GET.sort_by == "venue" or request.GET.sort_by == "-venue" %}hidden{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=-venue">
+                        <i title="Change to descending" class="bi bi-arrow-down asc-icon {% if request.GET.sort_by == "venue" %}active{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=venue">
+                        <i title="Change to ascending" class="bi bi-arrow-up desc-icon {% if request.GET.sort_by == "-venue" %}active{% endif %}"></i>
+                    </a>
                   </span>
                 </th>
                 <th scope="col" class="text-center">
                   Date
                   <span class="sort-icon" data-sort="date">
-                    <i title="Sort" class="bi bi-arrow-down-up default-icon"></i>
-                    <i title="Change to descending" class="bi bi-arrow-up asc-icon"></i>
-                    <i title="Change to ascending" class="bi bi-arrow-down desc-icon"></i>
+                    <a href="?sort_by=date">
+                        <i title="Sort" class="bi bi-arrow-down-up default-icon {% if request.GET.sort_by == "date" or request.GET.sort_by == "-date" %}hidden{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=-date">
+                        <i title="Change to descending" class="bi bi-arrow-down asc-icon {% if request.GET.sort_by == "date" %}active{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=date">
+                        <i title="Change to ascending" class="bi bi-arrow-up desc-icon {% if request.GET.sort_by == "-date" %}active{% endif %}"></i>
+                    </a>
                   </span>
                 </th>
                 <th class="text-center">Openers</th>

--- a/concert_elephant/templates/concerts/venue_list.html
+++ b/concert_elephant/templates/concerts/venue_list.html
@@ -17,10 +17,62 @@
         <table class="table table-striped table-hover">
           <thead class="table-custom">
             <tr>
-              <th class="text-center" scope="col">Venue</th>
-              <th class="text-center" scope="col">City</th>
-              <th class="text-center" scope="col">Country</th>
-              <th class="text-center" scope="col">Concerts</th>
+              <th class="text-center" scope="col">
+                  Venue
+                  <span class="sort-icon" data-sort="name">
+                      <a href="{% if request.GET.sort_by == "name" %}?sort_by=-name{% else %}?sort_by=name{% endif %}">
+                          <i title="Sort" class="bi bi-arrow-down-up default-icon {% if "name" in request.GET.sort_by or "-name" in request.GET.sort_by %}hidden{% endif %}"></i>
+                      </a>
+                      <a href="?sort_by=-name">
+                          <i title="Change to descending" class="bi bi-arrow-up asc-icon {% if request.GET.sort_by == "name" %}active{% endif %}"></i>
+                      </a>
+                      <a href="?sort_by=name">
+                          <i title="Change to ascending" class="bi bi-arrow-down desc-icon {% if request.GET.sort_by == "-name" %}active{% endif %}"></i>
+                      </a>
+                  </span>
+              </th>
+              <th class="text-center" scope="col">
+                  City
+                  <span class="sort-icon" data-sort="city">
+                      <a href="{% if request.GET.sort_by == "city" %}?sort_by=-city{% else %}?sort_by=city{% endif %}">
+                          <i title="Sort" class="bi bi-arrow-down-up default-icon {% if "city" in request.GET.sort_by or "-city" in request.GET.sort_by %}hidden{% endif %}"></i>
+                      </a>
+                      <a href="?sort_by=-city">
+                          <i title="Change to descending" class="bi bi-arrow-up asc-icon {% if request.GET.sort_by == "city" %}active{% endif %}"></i>
+                      </a>
+                      <a href="?sort_by=city">
+                          <i title="Change to ascending" class="bi bi-arrow-down desc-icon {% if request.GET.sort_by == "-city" %}active{% endif %}"></i>
+                      </a>
+                  </span>
+              </th>
+              <th class="text-center" scope="col">
+                  Country
+                  <span class="sort-icon" data-sort="country">
+                      <a href="{% if request.GET.sort_by == "country" %}?sort_by=-country{% else %}?sort_by=country{% endif %}">
+                          <i title="Sort" class="bi bi-arrow-down-up default-icon {% if "country" in request.GET.sort_by or "-country" in request.GET.sort_by %}hidden{% endif %}"></i>
+                      </a>
+                      <a href="?sort_by=-country">
+                          <i title="Change to descending" class="bi bi-arrow-up asc-icon {% if request.GET.sort_by == "country" %}active{% endif %}"></i>
+                      </a>
+                      <a href="?sort_by=country">
+                          <i title="Change to ascending" class="bi bi-arrow-down desc-icon {% if request.GET.sort_by == "-country" %}active{% endif %}"></i>
+                      </a>
+                  </span>
+              </th>
+              <th class="text-center" scope="col">
+                  Concerts
+                  <span class="sort-icon" data-sort="concert_count">
+                      <a href="{% if request.GET.sort_by == "concert_count" %}?sort_by=-concert_count{% else %}?sort_by=concert_count{% endif %}">
+                          <i title="Sort" class="bi bi-arrow-down-up default-icon {% if "concert_count" in request.GET.sort_by or "-concert_count" in request.GET.sort_by %}hidden{% endif %}"></i>
+                      </a>
+                      <a href="?sort_by=-concert_count">
+                          <i title="Change to descending" class="bi bi-arrow-up asc-icon {% if request.GET.sort_by == "concert_count" %}active{% endif %}"></i>
+                      </a>
+                      <a href="?sort_by=concert_count">
+                          <i title="Change to ascending" class="bi bi-arrow-down desc-icon {% if request.GET.sort_by == "-concert_count" %}active{% endif %}"></i>
+                      </a>
+                  </span>
+              </th>
             </tr>
           </thead>
           {% for venue in page_obj %}
@@ -29,7 +81,7 @@
               <td class="align-middle text-center">{{ venue.name }}</td>
               <td class="align-middle text-center">{{ venue.city }}</td>
               <td class="align-middle text-center">{{ venue.country }}</td>
-              <td class="align-middle text-center">{{ venue.concerts.count }}</td>
+              <td class="align-middle text-center">{{ venue.concert_count }}</td>
             </tr>
           {% endfor %}
         </table>

--- a/concert_elephant/templates/pagination_partial.html
+++ b/concert_elephant/templates/pagination_partial.html
@@ -1,29 +1,27 @@
 {% load custom_filters %}
 
 <div class="pagination justify-content-center mb-5">
-  <span class="step-links">
-    {% if paginator_data.has_previous %}
-      <a href="?page=1" class="btn btn-outline-primary text-white">&laquo; first</a>
-      <a href="?page={{ paginator_data.previous_page_number }}"
-         class="btn btn-outline-primary text-white">previous</a>
-    {% endif %}
-    {% for page_number in paginator_data.paginator.page_range %}
-      {% if page_number >= paginator_data.number|subtract:"2" and page_number <= paginator_data.number|add:"2" %}
-        {% if paginator_data.number == page_number %}
-          <button class="btn btn-outline-primary active text-white">
-            <span class="current-page">{{ paginator_data.number }}</span>
-          </button>
-        {% else %}
-          <a href="?page={{ page_number }}"
-             class="btn btn-outline-primary text-white">{{ page_number }}</a>
+    <span class="step-links">
+        {% if paginator_data.has_previous %}
+            <a href="?page=1{% if request.GET.sort_by %}&sort_by={{ request.GET.sort_by }}{% endif %}" class="btn btn-outline-primary text-white">&laquo; first</a>
+            <a href="?page={{ paginator_data.previous_page_number }}{% if request.GET.sort_by %}&sort_by={{ request.GET.sort_by }}{% endif %}" class="btn btn-outline-primary text-white">previous</a>
         {% endif %}
-      {% endif %}
-    {% endfor %}
-    {% if paginator_data.has_next %}
-      <a href="?page={{ paginator_data.next_page_number }}"
-         class="btn btn-outline-primary  text-white">next</a>
-      <a href="?page={{ paginator_data.paginator.num_pages }}"
-         class="btn btn-outline-primary  text-white">last &raquo;</a>
-    {% endif %}
-  </span>
+
+        {% for page_number in paginator_data.paginator.page_range %}
+            {% if page_number >= paginator_data.number|subtract:"2" and page_number <= paginator_data.number|add:"2" %}
+                {% if paginator_data.number == page_number %}
+                    <button class="btn btn-outline-primary active text-white">
+                        <span class="current-page">{{ paginator_data.number }}</span>
+                    </button>
+                {% else %}
+                    <a href="?page={{ page_number }}{% if request.GET.sort_by %}&sort_by={{ request.GET.sort_by }}{% endif %}" class="btn btn-outline-primary text-white">{{ page_number }}</a>
+                {% endif %}
+            {% endif %}
+        {% endfor %}
+
+        {% if paginator_data.has_next %}
+            <a href="?page={{ paginator_data.next_page_number }}{% if request.GET.sort_by %}&sort_by={{ request.GET.sort_by }}{% endif %}" class="btn btn-outline-primary  text-white">next</a>
+            <a href="?page={{ paginator_data.paginator.num_pages }}{% if request.GET.sort_by %}&sort_by={{ request.GET.sort_by }}{% endif %}" class="btn btn-outline-primary  text-white">last &raquo;</a>
+        {% endif %}
+    </span>
 </div>

--- a/concert_elephant/templates/users/user_detail.html
+++ b/concert_elephant/templates/users/user_detail.html
@@ -22,14 +22,55 @@
       {% if object == request.user %}
         <div class="table-responsive">
           <table class="table table-striped">
-            <tr>
-              <th class="col-2">Artist</th>
-              <th class="col-2 text-center">Venue</th>
-              <th class="col-2 text-center">Date</th>
-              <th class="col-2 text-center">Openers</th>
-              <th class="col-4">Review</th>
-              <th class="col-1"></th>
-            </tr>
+            <thead class="table-custom">
+              <tr>
+                <th class="col-2">
+                  Artist
+                  <span class="sort-icon" data-sort="artist">
+                    <a href="{% if request.GET.sort_by == "artist" %}?sort_by=-artist{% else %}?sort_by=artist{% endif %}">
+                      <i title="Sort" class="bi bi-arrow-down-up default-icon {% if "artist" in request.GET.sort_by or "-artist" in request.GET.sort_by %}hidden{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=-artist">
+                      <i title="Change to descending" class="bi bi-arrow-up asc-icon {% if request.GET.sort_by == "artist" %}active{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=artist">
+                      <i title="Change to ascending" class="bi bi-arrow-down desc-icon {% if request.GET.sort_by == "-artist" %}active{% endif %}"></i>
+                    </a>
+                  </span>
+                </th>
+                <th class="col-2 text-center">
+                  Venue
+                  <span class="sort-icon" data-sort="venue">
+                    <a href="{% if request.GET.sort_by == "venue" %}?sort_by=-venue{% else %}?sort_by=venue{% endif %}">
+                      <i title="Sort" class="bi bi-arrow-down-up default-icon {% if "venue" in request.GET.sort_by or "-venue" in request.GET.sort_by %}hidden{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=-venue">
+                      <i title="Change to descending" class="bi bi-arrow-up asc-icon {% if request.GET.sort_by == "venue" %}active{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=venue">
+                      <i title="Change to ascending" class="bi bi-arrow-down desc-icon {% if request.GET.sort_by == "-venue" %}active{% endif %}"></i>
+                    </a>
+                  </span>
+                </th>
+                <th class="col-2 text-center">
+                  Date
+                  <span class="sort-icon" data-sort="date">
+                    <a href="{% if request.GET.sort_by == "date" %}?sort_by=-date{% else %}?sort_by=date{% endif %}">
+                      <i title="Sort" class="bi bi-arrow-down-up default-icon {% if "date" in request.GET.sort_by or "-date" in request.GET.sort_by %}hidden{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=-date">
+                      <i title="Change to descending" class="bi bi-arrow-up asc-icon {% if request.GET.sort_by == "date" %}active{% endif %}"></i>
+                    </a>
+                    <a href="?sort_by=date">
+                      <i title="Change to ascending" class="bi bi-arrow-down desc-icon {% if request.GET.sort_by == "-date" %}active{% endif %}"></i>
+                    </a>
+                  </span>
+                </th>
+                <th class="col-2 text-center">Openers</th>
+                <th class="col-4">Review</th>
+                <th class="col-1"></th>
+              </tr>
+            </thead>
             {% for concert in concerts_with_reviews %}
               <tr data-concert-details-url="{% url 'concerts:concert-detail' concert.id %}">
                 <td class="align-middle">{{ concert.artist }}</td>

--- a/concert_elephant/users/views.py
+++ b/concert_elephant/users/views.py
@@ -1,8 +1,11 @@
+import logging
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.paginator import Paginator
 from django.db.models import Q
+from django.db.models.functions import Lower
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import DetailView, RedirectView, UpdateView
@@ -11,6 +14,7 @@ from concerts.forms import ConcertReviewForm
 from concerts.models import ConcertReview
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
 class UserDetailView(LoginRequiredMixin, DetailView):
@@ -18,6 +22,29 @@ class UserDetailView(LoginRequiredMixin, DetailView):
     slug_field = "username"
     slug_url_kwarg = "username"
     paginate_by = 10
+
+    def get_sorted_concerts(self, user):
+        logger.warning(f"Unrecognized sort option received: {self.request.GET.get('sort_by')}")
+        sort_by = self.request.GET.get("sort_by", "-date")
+        sort_options = ["artist", "-artist", "venue", "-venue", "date", "-date"]
+
+        if sort_by not in sort_options:
+            sort_by = "-date"
+
+        secondary_sort = "date"
+
+        if sort_by in ["artist", "-artist"]:
+            concerts = user.concerts.annotate(lower_artist=Lower("artist__name")).order_by(
+                sort_by.replace("artist", "lower_artist"), secondary_sort
+            )
+        elif sort_by in ["venue", "-venue"]:
+            concerts = user.concerts.annotate(lower_venue=Lower("venue__name")).order_by(
+                sort_by.replace("venue", "lower_venue"), secondary_sort
+            )
+        else:
+            concerts = user.concerts.order_by(sort_by)
+
+        return concerts
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -35,7 +62,7 @@ class UserDetailView(LoginRequiredMixin, DetailView):
                 )
             ]
         else:
-            concert_list = [concert for concert in user.concerts.all()]
+            concert_list = [concert for concert in self.get_sorted_concerts(user)]
 
         for concert in concert_list:
             concert.user_review = ConcertReview.objects.filter(user=user, concert=concert).first()

--- a/concerts/views.py
+++ b/concerts/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -12,6 +14,8 @@ from django.views.generic import CreateView, DetailView, ListView
 
 from .forms import ArtistForm, ConcertForm, ConcertReviewForm, VenueForm
 from .models import Artist, Concert, ConcertReview, Venue
+
+logger = logging.getLogger(__name__)
 
 
 def home_page(request):
@@ -110,7 +114,15 @@ class ArtistListView(ListView):
     paginate_by = 20
 
     def get_queryset(self):
-        return Artist.objects.all().order_by("-created_at")
+        logger.warning(f"Unrecognized sort option received: {self.request.GET.get('sort_by')}")
+        sort_options = ["name", "-name", "-created_at", "concert_count", "-concert_count"]
+        sort_by = self.request.GET.get("sort_by", "-created_at")
+        if sort_by not in sort_options:
+            sort_by = "-created_at"
+
+        queryset = Artist.objects.annotate(concert_count=Count("concerts")).order_by(sort_by)
+
+        return queryset
 
 
 class ArtistDetailView(DetailView):
@@ -175,7 +187,25 @@ class VenueListView(ListView):
     paginate_by = 20
 
     def get_queryset(self):
-        return Venue.objects.all().order_by("-created_at")
+        logger.warning(f"Unrecognized sort option received: {self.request.GET.get('sort_by')}")
+        sort_options = [
+            "name",
+            "-name",
+            "city",
+            "-city",
+            "country",
+            "-country",
+            "concert_count",
+            "-concert_count",
+            "-created_at",
+        ]
+        sort_by = self.request.GET.get("sort_by", "-created_at")
+        if sort_by not in sort_options:
+            sort_by = "-created_at"
+
+        queryset = Venue.objects.annotate(concert_count=Count("concerts")).order_by(sort_by)
+
+        return queryset
 
 
 class VenueDetailView(DetailView):
@@ -230,46 +260,25 @@ class ConcertListView(ListView):
     paginate_by = 20
 
     def get_queryset(self):
-        queryset = super().get_queryset()
-        # noinspection PyTypeChecker
-        sort_by = self.request.GET.get("sort_by", "date")
-        # noinspection PyTypeChecker
-        order = self.request.GET.get("order", "asc")
-        prefix = "-" if order == "desc" else ""
+        logger.warning(f"Unrecognized sort option received: {self.request.GET.get('sort_by')}")
+        sort_options = ["artist", "-artist", "venue", "-venue", "date", "-date"]
+        sort_by = self.request.GET.get("sort_by", "-date")
 
-        # For some reason, sorting is broken unless we compare the artist names after using Lower
-        # Something about being case-sensitive breaks it apparently
-        if sort_by == "artist":
-            if prefix:
-                queryset = queryset.annotate(lower_artist=Lower("artist__name")).order_by(f"{prefix}lower_artist")
-            else:
-                queryset = queryset.annotate(lower_artist=Lower("artist__name")).order_by("lower_artist")
+        if sort_by not in sort_options:
+            sort_by = "-date"
+
+        if sort_by == "artist" or sort_by == "-artist":
+            queryset = Concert.objects.annotate(lower_artist=Lower("artist__name")).order_by(
+                sort_by.replace("artist", "lower_artist")
+            )
+        elif sort_by == "venue" or sort_by == "-venue":
+            queryset = Concert.objects.annotate(lower_venue=Lower("venue__name")).order_by(
+                sort_by.replace("venue", "lower_venue")
+            )
         else:
-            queryset = queryset.order_by(f"{prefix}{sort_by}")
+            queryset = Concert.objects.order_by(sort_by)
+
         return queryset
-
-    def render_to_response(self, context, **response_kwargs):
-        if self.request.headers.get("X-Requested-With") == "XMLHttpRequest":
-            page_data = context.get("page_obj").object_list
-
-            data = []
-            for concert in page_data:
-                concert_data = {
-                    "pk": concert.pk,
-                    "fields": {
-                        "artist": str(concert.artist),
-                        "venue": str(concert.venue),
-                        "date": concert.date.strftime("%Y-%m-%d"),
-                        "openers": [str(opener) for opener in concert.opener.all()],
-                    },
-                }
-                data.append(concert_data)
-
-            sort_by = self.request.GET.get("sort_by", "date")
-            order = self.request.GET.get("order", "asc")
-
-            return JsonResponse({"concerts": data, "sort": {"column": sort_by, "direction": order}})
-        return super().render_to_response(context, **response_kwargs)
 
 
 class ConcertDetailView(DetailView):


### PR DESCRIPTION
Closes #72 

Greatly simplify compared to our previous attempts where we were using javascript. This uses django's context_data and querysets along with url parameters to get the job done.

- Sorting, ya know, works
- Icons to indicate you can sort, which column if any is sorted, and which direction it's sorted by
- Works with pagination
- Avoids SQLI by validating the sort_by option is one of the preapproved options
- Implements a secondary sort for venue column when looking at a list of concerts since that could very easily return with duplicates
