### PR TITLE
fix(concert-reviews): Show empty form when doing a concert review

### DIFF
--- a/concert_elephant/static/js/user_detail.js
+++ b/concert_elephant/static/js/user_detail.js
@@ -44,6 +44,16 @@ document.addEventListener("DOMContentLoaded", function() {
 
     showModalBtns.forEach(btn => {
         btn.addEventListener('click', (e) => {
+            e.stopPropagation();
+
+            // Clearing previous state
+            reviewText.value = '';
+            starRating.value = '';
+            reviewModal.querySelectorAll('input').forEach(input => {
+                if (input.type === "text" || input.type === "number") {
+                    input.value = '';
+                }
+            });
             const concertId = btn.getAttribute('data-concert-id');
             const row = e.currentTarget.closest('tr');
             const getConcertURL = row.getAttribute('data-concert-details-url');


### PR DESCRIPTION
Closes #140 

for some reason firefox was pulling in old reviews, but other browsers weren't. Use the hammer of forcing all fields to be blank when opening no matter the browser solves it. 